### PR TITLE
Corrected the installation process for Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,18 @@ Your application still runs the script itself (much like a database interaction)
 
 ## Node Quickstart
 
-You'll need Node version 8+ to install and run browserless.
+In order to run Browserless, you'll need:
+* Node version 8+
+* Chrome Dependencies: 
+  * `Sudo apt-get install -y  wget  unzip   fontconfig   locales  gconf-service   libasound2 libatk1.0-0   libc6   libcairo2   libcups2   libdbus-1-3   libexpat1   libfontconfig1   libgcc1   libgconf-2-4   libgdk-pixbuf2.0-0 libglib2.0-0   libgtk-3-0   libnspr4   libpango-1.0-0   libpangocairo-1.0-0   libstdc++6   libx11-6   libx11-xcb1   libxcb1 libxcomposite1   libxcursor1   libxdamage1   libxext6  libxfixes3   libxi6   libxrandr2   libxrender1   libxss1 libxtst6   ca-certificates   fonts-liberation   libappindicator1   libnss3   lsb-release   xdg-utils   wget`
+
+**Browserless Install**
 
 1. `git clone https://github.com/joelgriffith/browserless.git`
 2. `cd browserless`
 3. `npm install`
 4. `npm run dev`
-5. Visit `http://localhost:3000/` to use the interactive debugger.
+5. Visit `http://localhost:8080/` to use the interactive debugger.
 
 ## Debugger
 


### PR DESCRIPTION
The **Node Quickstart**in the Readme fails to finish to install because the installation does not include the dependencies to install. I added that in the install tutorial for unfamiliar users.

In addition the listening port for the debugger seems to be different on the Node install, appearing as: 
`const port = parseParam(process.env.PORT, 8080);`