### PR TITLE
Wait for content to load when generating PDF with HTML.

### DIFF
--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -25,7 +25,15 @@ module.exports = async function pdf({ page, context }) {
   if (url != null) {
     await page.goto(url);
   } else {
-    await page.setContent(html);
+    // Whilst there is no way of waiting for all requests to finish with setContent,
+    // you can simulate a webrequest this way
+    // see issue for more details: https://github.com/GoogleChrome/puppeteer/issues/728
+    await page.setRequestInterception(true);
+    page.once('request', request => {
+      request.respond({body: html});
+      page.on('request', request => request.continue());
+    });
+    await page.goto('http://localhost');
   }
 
   const data = await page.pdf(options);


### PR DESCRIPTION
At the moment, setContent can fail all resources (e.g. css, fonts, images) as it won't wait for the network to be idle.

Unfortunately, still waiting on a fix for that but the following code works around it by simulating a webrequest and replacing it with the HTML from the request. Can't see any impact on performance.