### PR TITLE
Feature/reject request list in functions

### DIFF
--- a/functions/content.js
+++ b/functions/content.js
@@ -18,7 +18,18 @@ module.exports = async function content ({ page, context }) {
   const {
     url,
     gotoOptions,
+    rejectRequestPattern,
   } = context;
+
+  if (rejectRequestPattern.length) {
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      if (rejectRequestPattern.find((pattern) => req.url().match(pattern))) {
+        return req.abort();
+      }
+      return req.continue();
+    });
+  }
 
   await page.goto(url, gotoOptions);
 

--- a/functions/pdf.js
+++ b/functions/pdf.js
@@ -62,7 +62,18 @@ module.exports = async function pdf({ page, context }) {
     url = null,
     safeMode,
     gotoOptions,
+    rejectRequestPattern,
   } = context;
+
+  if (rejectRequestPattern.length) {
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      if (rejectRequestPattern.find((pattern) => req.url().match(pattern))) {
+        return req.abort();
+      }
+      return req.continue();
+    });
+  }
 
   if (emulateMedia) {
     await page.emulateMedia(emulateMedia);

--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -24,7 +24,18 @@ module.exports = async function screenshot ({ page, context }) {
     gotoOptions,
     html,
     options = {},
+    rejectRequestPattern,
   } = context;
+
+  if (rejectRequestPattern.length) {
+    await page.setRequestInterception(true);
+    page.on('request', (req) => {
+      if (rejectRequestPattern.find((pattern) => req.url().match(pattern))) {
+        return req.abort();
+      }
+      return req.continue();
+    });
+  }
 
   if (url !== null) {
     await page.goto(url, gotoOptions);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import { BrowserlessServer } from './browserless-server';
+import { getDebug } from './utils';
+
+const debug = getDebug('system');
 
 const parseParam = (param: any, defaultParam: any) => {
   if (param) {
-    return JSON.parse(param);
+    try {
+      return JSON.parse(param);
+    } catch (err) {
+      debug(`Couldn't parse parameter: "${param}". Saw error "${err}"`);
+      return defaultParam;
+    }
   }
   return defaultParam;
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6,6 +6,8 @@ const gotoOptions = Joi.object().keys({
     .valid('load', 'domcontentloaded', 'networkidle0', 'networkidle2'),
 });
 
+const rejectRequestPattern = Joi.array().items(Joi.string()).default([]);
+
 export const screenshot = Joi.object().keys({
   gotoOptions,
   html: Joi.string(),
@@ -21,11 +23,13 @@ export const screenshot = Joi.object().keys({
     quality: Joi.number().min(0).max(100),
     type: Joi.string().valid('jpeg', 'png'),
   }),
+  rejectRequestPattern,
   url: Joi.string(),
 }).xor('url', 'html');
 
 export const content = Joi.object().keys({
   gotoOptions,
+  rejectRequestPattern,
   url: Joi.string().required(),
 });
 
@@ -52,6 +56,7 @@ export const pdf = Joi.object().keys({
     scale: Joi.number().min(0),
     width: Joi.any().optional(),
   }),
+  rejectRequestPattern,
   safeMode: Joi.boolean().default(
     false,
     'Whether to safely generate the PDF (renders pages one-at-a-time and merges it in-memory). ' +

--- a/src/tests/integration.spec.ts
+++ b/src/tests/integration.spec.ts
@@ -183,7 +183,7 @@ describe('Browserless Chrome', () => {
       await browser.close();
       const processes = await getChromeProcesses();
 
-      await sleep(10);
+      await sleep(50);
 
       expect(processes.stdout).not.toContain('.local-chromium');
     });

--- a/src/tests/integration.spec.ts
+++ b/src/tests/integration.spec.ts
@@ -40,7 +40,7 @@ const getChromeProcesses = () => {
 };
 
 const killChrome = () => {
-  return exec(`pkill -f .local-chromium`)
+  return exec(`pkill -f local-chromium`)
     .catch(() => {});
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,6 +29,10 @@ export const bodyValidation = (schema) => {
       return res.status(400).send(result.error.details);
     }
 
+    // Allow .defaults to work otherwise
+    // Joi schemas default's won't apply
+    req.body = result.value;
+
     return next();
   };
 };


### PR DESCRIPTION
Allows for the REST API's to specify an array of `rejectRequestPattern` to have the browser deny requests (IE: analytics and so on).