### PR TITLE
Don't close session every DELETE request

### DIFF
--- a/src/browserless-web-server.ts
+++ b/src/browserless-web-server.ts
@@ -319,8 +319,9 @@ export class BrowserlessServer {
   }
 
   private handleWebDriver(req, res) {
+    const sessionPathMatcher = new RegExp('^' + webDriverPath + '/\\w+$');
     const isStarting = req.method.toLowerCase() === 'post' && req.url === webDriverPath;
-    const isClosing = req.method.toLowerCase() === 'delete';
+    const isClosing = req.method.toLowerCase() === 'delete' && sessionPathMatcher.test(req.url);
 
     if (isStarting) {
       return this.webdriver.start(req, res);


### PR DESCRIPTION
This seems like a naive approach that is too aggressive in retrospect. The [selenium
documentation](https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#command-reference) shows that DELETEs are used for things like clearing cookies, local storage, closing windows, etc. This makes the check for attempted session closing more specific.