### PR TITLE
Pass through gotoOptions for html input screenshots

### DIFF
--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -55,12 +55,7 @@ module.exports = async function screenshot ({ page, context }) {
       page.on('request', request => request.continue());
     });
 
-    page.goto('http://localhost');
-
-    await Promise.race([
-      page.waitForNavigation({waitUntil: 'load'}),
-      page.waitForNavigation({waitUntil: 'networkidle0'})
-    ]);
+    await page.goto('http://localhost', gotoOptions);
   }
 
   const data = await page.screenshot(options);


### PR DESCRIPTION
Utilize gotoOptions when taking screenshots of HTML input.