### PR TITLE
Use node as executable instead npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,4 +122,4 @@ USER blessuser
 # Expose the web-socket and HTTP ports
 EXPOSE 3000
 ENTRYPOINT ["dumb-init", "--"]
-CMD [ "npm", "start" ]
+CMD [ "node", "./build/index.js" ]


### PR DESCRIPTION
When creating an image, you can bypass the package.json's start command and bake it directly into the image itself. First off this reduces the number of processes running inside of your container. Secondly it causes exit signals such as SIGTERM and SIGINT to be received by the Node.js process instead of npm swallowing them.

https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#cmd