### PR TITLE
intercept page http requests and provide custom http responses

### DIFF
--- a/functions/screenshot.js
+++ b/functions/screenshot.js
@@ -26,14 +26,24 @@ module.exports = async function screenshot ({ page, context }) {
     html,
     options = {},
     rejectRequestPattern,
+    requestInterceptors,
     viewport,
   } = context;
 
-  if (rejectRequestPattern.length) {
+  if (rejectRequestPattern.length || requestInterceptors.length) {
     await page.setRequestInterception(true);
     page.on('request', (req) => {
       if (rejectRequestPattern.find((pattern) => req.url().match(pattern))) {
         return req.abort();
+      }
+      const interceptor = requestInterceptors
+        .find(r => {
+          console.log(req.url());
+          console.log(req.url().match(r.pattern))
+          return req.url().match(r.pattern)
+        });
+      if (interceptor) {
+        return req.respond(interceptor.response);
       }
       return req.continue();
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
     },
     "@types/mkdirp": {
       "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
       "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
     },
     "@types/node": {
@@ -130,7 +130,7 @@
     },
     "@types/rimraf": {
       "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
       "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY="
     },
     "@types/serve-static": {
@@ -1974,7 +1974,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -2179,7 +2179,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -4140,7 +4140,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
             "lcid": "^1.0.0"
@@ -4148,7 +4148,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4166,7 +4166,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
             "camelcase": "^2.0.1",
@@ -4875,7 +4875,7 @@
     },
     "opn": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
       "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
       "requires": {
         "object-assign": "^4.0.1",
@@ -6777,7 +6777,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "timed-out": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browserless-chrome",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Chrome-as-a-service on your own hardware or in the cloud.",
   "repository": "joelgriffith/browserless",
   "main": "build/index.js",

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -8,6 +8,19 @@ const gotoOptions = Joi.object().keys({
 
 const rejectRequestPattern = Joi.array().items(Joi.string()).default([]);
 
+const requestInterceptors = Joi.array().items(Joi.object().keys({
+  pattern: Joi.string().required(),
+  response: Joi.object().keys({
+    body: Joi.alternatives([
+      Joi.string(),
+      Joi.binary(),
+    ]).required(),
+    contentType: Joi.string().required(),
+    headers: Joi.object(),
+    status: Joi.number().required(),
+  }),
+})).default([]);
+
 const cookies = Joi.array().items(Joi.object({
   domain: Joi.string(),
   expires: Joi.number().min(0),
@@ -46,6 +59,7 @@ export const screenshot = Joi.object().keys({
     type: Joi.string().valid('jpeg', 'png'),
   }),
   rejectRequestPattern,
+  requestInterceptors,
   url: Joi.string(),
   viewport,
 }).xor('url', 'html');

--- a/src/tests/integration/http.spec.ts
+++ b/src/tests/integration/http.spec.ts
@@ -512,6 +512,38 @@ describe('Browserless Chrome HTTP', () => {
         });
     });
 
+    it('allows for providing http response payloads', async () => {
+      const params = defaultParams();
+      const browserless = start(params);
+
+      await browserless.startServer();
+
+      const body = {
+        requestInterceptors: [
+          {
+            pattern: '.*data\.json',
+            response: {
+              body: '{"data": 123}',
+              contentType: 'application/json',
+              status: 200,
+            },
+          },
+        ],
+        url: 'https://example.com',
+      };
+
+      return fetch(`http://localhost:${params.port}/screenshot`, {
+        body: JSON.stringify(body),
+        headers: {
+          'content-type': 'application/json',
+        },
+        method: 'POST',
+      })
+        .then((res) => {
+          expect(res.status).toBe(200);
+        });
+    });
+
     it('allows for injecting HTML', async () => {
       const params = defaultParams();
       const browserless = start(params);


### PR DESCRIPTION
When making a request for a screenshot,  I wanted the ability to pass along any data the page may request. This way I can avoid the round trip to any rest apis the page may be calling and provide the data directly from Browserless. Let me know what you think about this.