### PR TITLE
Debugger updates, test fixes for rejections

### DIFF
--- a/debugger/index.html
+++ b/debugger/index.html
@@ -339,8 +339,6 @@ module.exports = async ({ page }) => {
 <script>
   const { port, hostname, protocol } = window.location;
   const baseURL = `${protocol}//${hostname}${port ? `:${port}` : ''}`;
-  const token = new URLSearchParams(window.location.search).get('token');
-  const qsParams = token ? `?token=${token}`: '';
   const secure = /(https)|(wss)/g.test(protocol);
   const AUTO_COMPLETE_AFTER_KEY = /^[a-zA-Z0-9_@(]$/;
   const globalVars = [
@@ -365,7 +363,7 @@ module.exports = async ({ page }) => {
   const $about = document.querySelector('#about');
   const $download = document.querySelector('#download');
 
-  const save = (code) => window.localStorage.setItem(key, code);
+  const save = (code) => document.cookie = `${key}=code`;
   const previousCode = window.localStorage.getItem(key);
   const rand = (arr) => arr[Math.floor(Math.random() * arr.length)];
   const README = `
@@ -592,7 +590,7 @@ const puppeteer = require('puppeteer');
     }
 
     const stringifiedCode = encodeURIComponent(code);
-    const params = `/debugger/${stringifiedCode}` + qsParams;
+    const params = `/debugger/${stringifiedCode}`;
     const wsLocation = `${hostname}${port ? `:${port}` : ''}${params}`;
 
     $debugFrame.src = `https://chrome-devtools-frontend.appspot.com/serve_file/@${debuggerVersion}/inspector.html?remoteFrontend=true&${secure ? 'wss' : 'ws'}=${wsLocation}`;
@@ -640,7 +638,7 @@ const puppeteer = require('puppeteer');
     onEditScript(editor.getValue());
   });
 
-  fetch(`${baseURL}/introspection${qsParams}`, {
+  fetch(`${baseURL}/introspection`, {
     headers: {
       'Accept': 'application/json',
     }
@@ -648,7 +646,7 @@ const puppeteer = require('puppeteer');
   .then(res => res.json())
   .then((hints) => pageMethods = pageMethods.concat(hints))
 
-  fetch(`${baseURL}/json/version${qsParams}`, {
+  fetch(`${baseURL}/json/version`, {
     headers: {
       'Accept': 'application/json',
     }

--- a/debugger/index.html
+++ b/debugger/index.html
@@ -363,7 +363,7 @@ module.exports = async ({ page }) => {
   const $about = document.querySelector('#about');
   const $download = document.querySelector('#download');
 
-  const save = (code) => document.cookie = `${key}=code`;
+  const save = (code) => window.localStorage.setItem(key, code);
   const previousCode = window.localStorage.getItem(key);
   const rand = (arr) => arr[Math.floor(Math.random() * arr.length)];
   const README = `
@@ -590,8 +590,8 @@ const puppeteer = require('puppeteer');
     }
 
     const stringifiedCode = encodeURIComponent(code);
-    const params = `/debugger/${stringifiedCode}`;
-    const wsLocation = `${hostname}${port ? `:${port}` : ''}${params}`;
+    document.cookie = `browserless_code=${stringifiedCode}`;
+    const wsLocation = `${hostname}${port ? `:${port}` : ''}/debugger`;
 
     $debugFrame.src = `https://chrome-devtools-frontend.appspot.com/serve_file/@${debuggerVersion}/inspector.html?remoteFrontend=true&${secure ? 'wss' : 'ws'}=${wsLocation}`;
   };
@@ -664,6 +664,6 @@ const puppeteer = require('puppeteer');
 </script>
 
 <!-- Inject public metrics and carbon on non-paid debugger instances -->
-<script>if('chrome.browserless.io'===window.location.host&&!window.location.search.includes('?token=')){function a(){dataLayer.push(arguments)}const b=document.createElement('script'),c=document.createElement('script');b.src='//www.googletagmanager.com/gtag/js?id=UA-105866025-3',b.async=!0,c.src='//cdn.carbonads.com/carbon.js?serve=CK7DV23E&placement=wwwbrowserlessio',c.async=!0,c.id='_carbonads_js',document.head.appendChild(b),document.querySelector('footer').appendChild(c),window.dataLayer=window.dataLayer||[],a('js',new Date),a('config','UA-105866025-1')}</script>
+<script>if('chrome.browserless.io'===window.location.host&&!window.location.search.includes('?token=')){function a(){dataLayer.push(arguments)}const b=document.createElement('script'),c=document.createElement('script');b.src='//www.googletagmanager.com/gtag/js?id=UA-105866025-3',b.async=!0,c.src='//cdn.carbonads.com/carbon.js?serve=CK7DV23E&placement=wwwbrowserlessio',c.async=!0,c.id='_carbonads_js',document.head.appendChild(b),document.querySelector('footer').appendChild(c),window.dataLayer=window.dataLayer||[],a('js',new Date),a('config','UA-105866025-3')}</script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/puppeteer": "^1.10.0",
     "body-parser": "^1.18.2",
     "chromedriver": "^2.41.0",
+    "cookie": "^0.3.1",
     "cors": "^2.8.4",
     "debug": "^4.0.0",
     "express": "^4.16.2",

--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -1,3 +1,4 @@
+import * as cookie from 'cookie';
 import * as _ from 'lodash';
 import * as puppeteer from 'puppeteer';
 import * as url from 'url';
@@ -8,7 +9,7 @@ import { BrowserlessServer } from './browserless';
 import { convertUrlParamsToLaunchOpts, defaultLaunchArgs, launchChrome } from './chrome-helper';
 import { Queue } from './queue';
 import { BrowserlessSandbox } from './Sandbox';
-import { getDebug, id } from './utils';
+import { codeCookieName, getDebug, id } from './utils';
 
 import { IChromeServiceConfiguration } from './models/options.interface';
 import { IDone, IJob } from './models/queue.interface';
@@ -251,20 +252,15 @@ export class ChromeService {
     const jobId = id();
     const parsedUrl: any = url.parse(req.url, true);
     const route = parsedUrl.pathname || '/';
-    const hasDebugCode = parsedUrl.pathname && parsedUrl.pathname.includes('/debugger/');
+    const hasDebugCode = parsedUrl.pathname && parsedUrl.pathname.includes('/debugger');
     const debugCode = hasDebugCode ?
-      parsedUrl.pathname.replace('/debugger/', '') :
+      cookie.parse(req.headers.cookie)[codeCookieName] :
       '';
 
     jobdebug(`${jobId}: ${req.url}: Inbound WebSocket request.`);
 
     if (this.config.demoMode && !debugCode) {
       jobdebug(`${jobId}: No demo code sent, running in demo mode, closing with 403.`);
-      return this.server.rejectSocket(req, socket, `HTTP/1.1 403 Forbidden`);
-    }
-
-    if (this.config.token && !req.url.includes(this.config.token)) {
-      jobdebug(`${jobId}: No token sent, closing with 403.`);
       return this.server.rejectSocket(req, socket, `HTTP/1.1 403 Forbidden`);
     }
 
@@ -280,7 +276,7 @@ export class ChromeService {
     const handler = debugCode ?
       (done: IDone) => {
         jobdebug(`${job.id}: Starting debugger sandbox.`);
-        const code = this.parseUserCode(decodeURIComponent(debugCode), job);
+        const code = this.parseUserCode(debugCode, job);
         const timeout = this.config.connectionTimeout;
         const handler = new BrowserlessSandbox({
           code,

--- a/src/tests/integration/websockets.spec.ts
+++ b/src/tests/integration/websockets.spec.ts
@@ -143,7 +143,7 @@ describe('Browserless Chrome WebSockets', () => {
       .then(throws)
       .catch((error) => {
         expect(browserless.currentStat.successful).toEqual(0);
-        expect(browserless.currentStat.rejected).toEqual(1);
+        expect(browserless.currentStat.rejected).toEqual(0);
         expect(browserless.currentStat.queued).toEqual(0);
         expect(error.message).toEqual(`socket hang up`);
       });
@@ -162,7 +162,7 @@ describe('Browserless Chrome WebSockets', () => {
       .then(throws)
       .catch((error) => {
         expect(browserless.currentStat.successful).toEqual(0);
-        expect(browserless.currentStat.rejected).toEqual(1);
+        expect(browserless.currentStat.rejected).toEqual(0);
         expect(browserless.currentStat.queued).toEqual(0);
         expect(error.message).toEqual(`socket hang up`);
       });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,9 @@ export const bodyValidation = (schema) => {
   };
 };
 
+export const tokenCookieName = 'browserless_token';
+export const codeCookieName = 'browserless_code';
+
 export const generateChromeTarget = () => {
   return `/devtools/page/${id()}`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,11 @@
+import * as cookie from 'cookie';
 import * as fs from 'fs';
 import * as Joi from 'joi';
+import * as _ from 'lodash';
 import * as os from 'os';
 import * as path from 'path';
 import * as shortid from 'shortid';
+import * as url from 'url';
 import * as util from 'util';
 
 const debug = require('debug');
@@ -48,6 +51,20 @@ export const bodyValidation = (schema) => {
 
 export const tokenCookieName = 'browserless_token';
 export const codeCookieName = 'browserless_code';
+
+export const isAuthorized = (req, token) => {
+  const cookies = cookie.parse(req.headers.cookie || '');
+  const parsedUrl = url.parse(req.url as string, true);
+  const authToken = _.get(parsedUrl, 'query.token', null) ||
+    getBasicAuthToken(req) ||
+    cookies[tokenCookieName];
+
+  if (authToken !== token) {
+    return false;
+  }
+
+  return true;
+};
 
 export const generateChromeTarget = () => {
   return `/devtools/page/${id()}`;


### PR DESCRIPTION
Moves debugger over to cookies for transporting code (unfortunately doing it via the URL is too fragile, and cookies are the only other way). Also allows for authing via cookie.

This also doesn't log unauthorized requests as "rejected" since they weren't authorized to begin with.