### PR TITLE
Default args + other options in env variables

### DIFF
--- a/src/chrome-helper.ts
+++ b/src/chrome-helper.ts
@@ -5,17 +5,29 @@ import * as express from 'express';
 import * as fs from 'fs';
 import { IncomingMessage } from 'http';
 import * as _ from 'lodash';
-import { Browser, LaunchOptions } from 'puppeteer';
+import * as puppeteer from 'puppeteer';
 import * as url from 'url';
-import { DISABLE_AUTO_SET_DOWNLOAD_BEHAVIOR, ENABLE_DEBUG_VIEWER, HOST, PORT, WORKSPACE_DIR } from './config';
 import { canLog, fetchJson, getDebug, getUserDataDir, rimraf } from './utils';
 
-const puppeteer = require('puppeteer');
+import {
+  DEFAULT_BLOCK_ADS,
+  DEFAULT_HEADLESS,
+  DEFAULT_IGNORE_DEFAULT_ARGS,
+  DEFAULT_IGNORE_HTTPS_ERRORS,
+  DEFAULT_LAUNCH_ARGS,
+  DEFAULT_USER_DATA_DIR,
+  DISABLE_AUTO_SET_DOWNLOAD_BEHAVIOR,
+  ENABLE_DEBUG_VIEWER,
+  HOST,
+  PORT,
+  WORKSPACE_DIR,
+} from './config';
+
 const debug = getDebug('chrome-helper');
 const getPort = require('get-port');
 const packageJson = require('puppeteer/package.json');
 const CHROME_BINARY_LOCATION = '/usr/bin/google-chrome';
-const DEFAULT_ARGS = ['--no-sandbox', '--disable-dev-shm-usage', '--enable-logging', '--v1=1'];
+const BROWSERLESS_ARGS = ['--no-sandbox', '--disable-dev-shm-usage', '--enable-logging', '--v1=1'];
 const blacklist = require('../hosts.json');
 
 let executablePath: string;
@@ -26,7 +38,7 @@ export interface IChromeDriver {
   chromeProcess: ChildProcess;
 }
 
-interface IBrowser extends Browser {
+interface IBrowser extends puppeteer.Browser {
   port: string | undefined;
 }
 
@@ -41,7 +53,7 @@ interface ISession {
   port: string;
 }
 
-export interface ILaunchOptions extends LaunchOptions {
+export interface ILaunchOptions extends puppeteer.LaunchOptions {
   pauseOnConnect: boolean;
   blockAds: boolean;
 }
@@ -59,30 +71,14 @@ if (fs.existsSync(CHROME_BINARY_LOCATION)) {
 }
 
 export const defaultLaunchArgs = {
-  args: [],
-  blockAds: false,
-  headless: true,
-  ignoreDefaultArgs: false,
-  ignoreHTTPSErrors: false,
+  args: DEFAULT_LAUNCH_ARGS,
+  blockAds: DEFAULT_BLOCK_ADS,
+  headless: DEFAULT_HEADLESS,
+  ignoreDefaultArgs: DEFAULT_IGNORE_DEFAULT_ARGS,
+  ignoreHTTPSErrors: DEFAULT_IGNORE_HTTPS_ERRORS,
   pauseOnConnect: false,
   slowMo: undefined,
-  userDataDir: undefined,
-};
-
-const parseIgnoreDefaultArgs = (argsString: string | string[]): boolean | string[] => {
-  if (Array.isArray(argsString)) {
-    return argsString;
-  }
-
-  if (argsString === 'true' || argsString === 'false') {
-    return argsString === 'true';
-  }
-
-  if (argsString.includes(',')) {
-    return argsString.split(',');
-  }
-
-  return false;
+  userDataDir: DEFAULT_USER_DATA_DIR,
 };
 
 export const getRandomSession = () => _.sample(runningBrowsers) as IBrowser | undefined;
@@ -123,11 +119,11 @@ export const getDebuggingPages = async (): Promise<ISession[]> => {
   return _.flatten(results);
 };
 
-export const launchChrome = async (opts: ILaunchOptions): Promise<Browser> => {
-  let browserlessDataDir: string | null = null;
+export const launchChrome = async (opts: ILaunchOptions): Promise<puppeteer.Browser> => {
+  const browserlessDataDir = opts.userDataDir;
   const launchArgs = {
     ...opts,
-    args: [...opts.args || [], ...DEFAULT_ARGS],
+    args: [...opts.args || [], ...BROWSERLESS_ARGS],
     executablePath,
     handleSIGINT: false,
     handleSIGTERM: false,
@@ -136,9 +132,8 @@ export const launchChrome = async (opts: ILaunchOptions): Promise<Browser> => {
   const hasUserDataDir = _.some((launchArgs.args), (arg) => arg.includes('--user-data-dir='));
 
   // If no data-dir is set, build one that is managed by us and cleanedup after
-  if (!hasUserDataDir) {
-    browserlessDataDir = await getUserDataDir();
-    launchArgs.args.push(`--user-data-dir=${browserlessDataDir}`);
+  if (!hasUserDataDir && !browserlessDataDir) {
+    launchArgs.args.push(`--user-data-dir=${await getUserDataDir()}`);
   }
 
   debug(`Launching Chrome with args: ${JSON.stringify(launchArgs, null, '  ')}`);
@@ -214,16 +209,14 @@ export const convertUrlParamsToLaunchOpts = (req: IncomingMessage | express.Requ
   } = urlParts.query;
 
   return {
-    args: args as string[],
-    blockAds: typeof blockAds !== 'undefined',
-    headless: headless !== 'false',
-    ignoreDefaultArgs: ignoreDefaultArgs ?
-      parseIgnoreDefaultArgs(ignoreDefaultArgs) :
-      false,
-    ignoreHTTPSErrors: ignoreHTTPSErrors === 'true',
-    pauseOnConnect: typeof pause !== 'undefined',
+    args: !_.isEmpty(args) ? args : DEFAULT_LAUNCH_ARGS,
+    blockAds: !_.isUndefined(blockAds) || DEFAULT_BLOCK_ADS,
+    headless: !_.isUndefined(headless) || DEFAULT_HEADLESS,
+    ignoreDefaultArgs: !_.isUndefined(ignoreDefaultArgs) || DEFAULT_IGNORE_DEFAULT_ARGS,
+    ignoreHTTPSErrors: !_.isUndefined(ignoreHTTPSErrors) || DEFAULT_IGNORE_HTTPS_ERRORS,
+    pauseOnConnect: !_.isUndefined(pause),
     slowMo: parseInt(slowMo as string, 10) || undefined,
-    userDataDir: userDataDir as string,
+    userDataDir: userDataDir as string || DEFAULT_USER_DATA_DIR,
   };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,32 +14,51 @@ const parseJSONParam = (param: string | undefined, defaultParam: number | boolea
 
 const thirtyMinutes = 30 * 60 * 1000;
 
-export const CONNECTION_TIMEOUT: number =         parseJSONParam(process.env.CONNECTION_TIMEOUT, 30000);
-export const MAX_CONCURRENT_SESSIONS: number =    parseJSONParam(process.env.MAX_CONCURRENT_SESSIONS, 10);
-export const QUEUE_LENGTH: number =               parseJSONParam(process.env.MAX_QUEUE_LENGTH, 10);
-export const PORT: number =                       parseJSONParam(process.env.PORT, 8080);
-export const PREBOOT_CHROME: boolean =            parseJSONParam(process.env.PREBOOT_CHROME, false);
-export const DEMO_MODE: boolean =                 parseJSONParam(process.env.DEMO_MODE, false);
-export const ENABLE_DEBUG_VIEWER: boolean =       parseJSONParam(process.env.ENABLE_DEBUG_VIEWER, true);
-export const ENABLE_DEBUGGER: boolean =           parseJSONParam(process.env.ENABLE_DEBUGGER, true);
-export const MAX_MEMORY_PERCENT: number =         parseJSONParam(process.env.MAX_MEMORY_PERCENT, 99);
-export const MAX_CPU_PERCENT: number =            parseJSONParam(process.env.MAX_CPU_PERCENT, 99);
-export const KEEP_ALIVE: boolean =                parseJSONParam(process.env.KEEP_ALIVE, false);
-export const CHROME_REFRESH_TIME: number =        parseJSONParam(process.env.CHROME_REFRESH_TIME, thirtyMinutes);
+// Timers/Queue/Concurrency
+export const CHROME_REFRESH_TIME: number = parseJSONParam(process.env.CHROME_REFRESH_TIME, thirtyMinutes);
+export const CONNECTION_TIMEOUT: number = parseJSONParam(process.env.CONNECTION_TIMEOUT, 30000);
+export const MAX_CONCURRENT_SESSIONS: number = parseJSONParam(process.env.MAX_CONCURRENT_SESSIONS, 10);
+export const QUEUE_LENGTH: number = parseJSONParam(process.env.MAX_QUEUE_LENGTH, 10);
+
+// Preboot/Default Launch Options
+export const KEEP_ALIVE: boolean = parseJSONParam(process.env.KEEP_ALIVE, false);
 export const MAX_CHROME_REFRESH_RETRIES: number = parseJSONParam(process.env.MAX_CHROME_REFRESH_RETRIES, 5);
-export const ENABLE_CORS: boolean  =              parseJSONParam(process.env.ENABLE_CORS, false);
-export const ENABLE_XVBF: boolean =               parseJSONParam(process.env.ENABLE_XVBF, false);
-export const EXIT_ON_HEALTH_FAILURE: boolean =    parseJSONParam(process.env.EXIT_ON_HEALTH_FAILURE, false);
-export const HOST: string | undefined =           process.env.HOST;
-export const TOKEN: string | null =               process.env.TOKEN || null;
-export const QUEUE_ALERT_URL: string | null =     process.env.QUEUE_ALERT_URL || null;
-export const REJECT_ALERT_URL: string | null =    process.env.REJECT_ALERT_URL || null;
-export const TIMEOUT_ALERT_URL: string | null =   process.env.TIMEOUT_ALERT_URL || null;
-export const FAILED_HEALTH_URL: string | null =   process.env.FAILED_HEALTH_URL || null;
-export const METRICS_JSON_PATH: string | null =   process.env.METRICS_JSON_PATH || null;
-export const FUNCTION_BUILT_INS: string[] =       parseJSONParam(process.env.FUNCTION_BUILT_INS, []);
-export const FUNCTION_EXTERNALS: string[] =       parseJSONParam(process.env.FUNCTION_EXTERNALS, []);
-export const WORKSPACE_DIR: string =              process.env.WORKSPACE_DIR ? process.env.WORKSPACE_DIR : os.tmpdir();
-export const DEBUG: string | undefined =          process.env.DEBUG;
-export const MAX_PAYLOAD_SIZE: string =           process.env.MAX_PAYLOAD_SIZE || '5mb';
+export const DEFAULT_BLOCK_ADS: boolean = parseJSONParam(process.env.DEFAULT_BLOCK_ADS, false);
+export const DEFAULT_HEADLESS: boolean = parseJSONParam(process.env.DEFAULT_CHROME, true);
+export const DEFAULT_LAUNCH_ARGS: string[] = parseJSONParam(process.env.DEFAULT_LAUNCH_ARGS, []);
+export const DEFAULT_IGNORE_DEFAULT_ARGS: boolean = parseJSONParam(process.env.DEFAULT_IGNORE_DEFAULT_ARGS, false);
+export const DEFAULT_IGNORE_HTTPS_ERRORS: boolean = parseJSONParam(process.env.DEFAULT_IGNORE_HTTPS_ERRORS, false);
+export const DEFAULT_USER_DATA_DIR: string | undefined = process.env.DEFAULT_USER_DATA_DIR;
+export const PREBOOT_CHROME: boolean = parseJSONParam(process.env.PREBOOT_CHROME, false);
+
+// Security and accessibility
+export const DEBUG: string | undefined = process.env.DEBUG;
+export const DEMO_MODE: boolean = parseJSONParam(process.env.DEMO_MODE, false);
+export const ENABLE_CORS: boolean  = parseJSONParam(process.env.ENABLE_CORS, false);
+export const ENABLE_DEBUGGER: boolean = parseJSONParam(process.env.ENABLE_DEBUGGER, true);
+export const ENABLE_DEBUG_VIEWER: boolean = parseJSONParam(process.env.ENABLE_DEBUG_VIEWER, true);
+export const ENABLE_XVBF: boolean = parseJSONParam(process.env.ENABLE_XVBF, false);
+export const TOKEN: string | null = process.env.TOKEN || null;
+
+// Puppeteer behavior
 export const DISABLE_AUTO_SET_DOWNLOAD_BEHAVIOR = parseJSONParam(process.env.DISABLE_AUTO_SET_DOWNLOAD_BEHAVIOR, false);
+export const FUNCTION_BUILT_INS: string[] = parseJSONParam(process.env.FUNCTION_BUILT_INS, []);
+export const FUNCTION_EXTERNALS: string[] = parseJSONParam(process.env.FUNCTION_EXTERNALS, []);
+export const WORKSPACE_DIR: string = process.env.WORKSPACE_DIR ? process.env.WORKSPACE_DIR : os.tmpdir();
+
+// Webhooks
+export const FAILED_HEALTH_URL: string | null = process.env.FAILED_HEALTH_URL || null;
+export const QUEUE_ALERT_URL: string | null = process.env.QUEUE_ALERT_URL || null;
+export const REJECT_ALERT_URL: string | null = process.env.REJECT_ALERT_URL || null;
+export const TIMEOUT_ALERT_URL: string | null = process.env.TIMEOUT_ALERT_URL || null;
+
+// Health
+export const EXIT_ON_HEALTH_FAILURE: boolean = parseJSONParam(process.env.EXIT_ON_HEALTH_FAILURE, false);
+export const MAX_CPU_PERCENT: number = parseJSONParam(process.env.MAX_CPU_PERCENT, 99);
+export const MAX_MEMORY_PERCENT: number = parseJSONParam(process.env.MAX_MEMORY_PERCENT, 99);
+export const METRICS_JSON_PATH: string | null = process.env.METRICS_JSON_PATH || null;
+
+// Server Options
+export const HOST: string | undefined = process.env.HOST;
+export const MAX_PAYLOAD_SIZE: string = process.env.MAX_PAYLOAD_SIZE || '5mb';
+export const PORT: number = parseJSONParam(process.env.PORT, 8080);

--- a/src/puppeteer-provider.ts
+++ b/src/puppeteer-provider.ts
@@ -90,7 +90,7 @@ export class PuppeteerProvider {
       sysdebug(`Starting chrome swarm: ${this.config.maxConcurrentSessions} chrome instances starting`);
 
       if (this.config.maxConcurrentSessions > 10) {
-        process.setMaxListeners(this.config.maxConcurrentSessions + 2);
+        process.setMaxListeners(this.config.maxConcurrentSessions + 3);
       }
 
       const launching = Array.from({ length: this.config.maxConcurrentSessions }, () => {
@@ -106,8 +106,7 @@ export class PuppeteerProvider {
 
     if (this.config.enableXvfb) {
       const xvfb = new XVFB();
-      const start = promisify(xvfb.start.bind(xvfb));
-      await start();
+      await promisify(xvfb.start.bind(xvfb))();
     }
 
     return Promise.resolve();


### PR DESCRIPTION
Allows setting of default args for launching chrome + others (as separate args). I went the route if separating these out to make it easier, and more explicit, that options are set.

**When defaults are set and a requests comes in with preboot**
- Chrome will launched with these defaults.
- If options are specified that _match_ these defaults, prebooted instances are used.
- Only when there's a discrepancy do we launch Chrome custom-configured for the request.
